### PR TITLE
bugfix#fix the error that remove peer in handshake phase from pending…

### DIFF
--- a/p2p.go
+++ b/p2p.go
@@ -489,6 +489,7 @@ RETRY:
 	err := service.addPendingPeer(peer)
 	if err != nil {
 		log.Error("failed To add peer %s To pending list, as: %v", peer.GetAddr().ToString(), err)
+		return
 	} else {
 		err = peer.Start()
 	}


### PR DESCRIPTION
… queue

1. return directly when peer already in pending queue